### PR TITLE
Seed galaxy map from /api/map at startup

### DIFF
--- a/src/botmanager.ts
+++ b/src/botmanager.ts
@@ -329,6 +329,19 @@ async function main(): Promise<void> {
   server.logSystem("Loading saved sessions...");
 
   discoverBots();
+
+  // Seed galaxy map from public API so pathfinding works from first run
+  server.logSystem("Seeding galaxy map from /api/map...");
+  mapStore.seedFromMapAPI().then(({ seeded, known, failed }) => {
+    if (failed) {
+      server.logSystem("Galaxy map seed failed — will rely on exploration data");
+    } else {
+      server.logSystem(`Galaxy map seeded: ${seeded} new system(s), ${known} already known`);
+    }
+  }).catch(() => {
+    server.logSystem("Galaxy map seed failed — will rely on exploration data");
+  });
+
   if (bots.size > 0) {
     server.logSystem(`Found ${bots.size} saved bot(s): ${[...bots.keys()].join(", ")}`);
     for (const [, bot] of bots) {


### PR DESCRIPTION
## Summary

- Fetches `https://game.spacemolt.com/api/map` once at startup and seeds all system connections into `mapStore`
- BFS pathfinding (`findRoute`, `findNearestStationSystem`) now works galaxy-wide from the first run, without needing the explorer to visit every system first
- Existing POI, market, and ore data is fully preserved via `updateSystem`'s merge logic
- Fires async after `discoverBots()`, logging results to the system panel
- Falls back gracefully if the endpoint is unreachable

## Details

### `MapStore.seedFromMapAPI()`
New public method on `MapStore`:
1. Fetches `/api/map` with a 15s timeout
2. Builds an ID → name lookup from the full system list
3. Transforms each system's flat connection ID array into `StoredConnection` objects (with resolved names)
4. Calls `updateSystem()` for each system — new systems are added, existing ones have connections updated while all other data (POIs, market orders, ore locations) is preserved

### `botmanager.ts`
Calls `seedFromMapAPI()` async in `main()` immediately after `discoverBots()`. Logs one of:
- `Galaxy map seeded: N new system(s), K already known`
- `Galaxy map seed failed — will rely on exploration data`

## Test plan

- [ ] Fresh start with no saved map data — confirm system log shows `Galaxy map seeded: N new system(s)`
- [ ] Verify explorer and trader can plan routes to unvisited systems immediately after startup
- [ ] Start with existing map data — confirm `already known` count matches previously explored systems and no POI/market data is lost
- [ ] Simulate API failure (e.g. bad URL) — confirm fallback message appears and bot manager starts normally