### PR TITLE
Fix routine select dropdown closing on WebSocket status updates

### DIFF
--- a/src/web/index.html
+++ b/src/web/index.html
@@ -2216,7 +2216,8 @@ function connect() {
         break;
       case 'status':
         bots = msg.bots || [];
-        renderBots();
+        // Skip re-rendering the bot list if a routine select is focused (user is picking)
+        if (!document.activeElement?.closest?.('.row-actions')) renderBots();
         renderStats();
         updateChatBotSelect();
         // Update profile if open


### PR DESCRIPTION
## Summary

- The routine select pulldown in the bot list was being destroyed and recreated on every WebSocket `status` message, closing any open dropdown before the user could make a selection
- Added a guard in the `status` message handler: skip `renderBots()` if the focused element is inside `.row-actions` (where the select lives)

## Test plan

- [ ] Open the bot runner UI
- [ ] Click the routine select dropdown for a bot
- [ ] Verify the dropdown stays open long enough to select an option without being dismissed by a status update