### PR TITLE
Hunter: respond to faction combat alerts from allied bots

### DIFF
--- a/src/routines/hunter.ts
+++ b/src/routines/hunter.ts
@@ -52,6 +52,7 @@ function getHunterSettings(username?: string): {
   repairThreshold: number;
   fleeThreshold: number;
   onlyNPCs: boolean;
+  responseRange: number;
 } {
   const all = readSettings();
   const h = all.hunter || {};
@@ -63,6 +64,7 @@ function getHunterSettings(username?: string): {
     repairThreshold: (h.repairThreshold as number) || 30,
     fleeThreshold: (h.fleeThreshold as number) || 20,
     onlyNPCs: (h.onlyNPCs as boolean) !== false,
+    responseRange: (h.responseRange as number) ?? 3,
   };
 }
 
@@ -486,6 +488,77 @@ function findNextHuntSystem(fromSystemId: string): string | null {
   return null;
 }
 
+// ── Faction alert response ────────────────────────────────────
+
+/** Cooldown per system so we don't divert repeatedly (5 minutes). */
+const ALERT_RESPONSE_COOLDOWN_MS = 5 * 60 * 1000;
+/** Ignore faction alerts older than this (seconds, if API returns Unix time). */
+const ALERT_STALENESS_SECS = 5 * 60;
+
+/** Map<systemId, lastRespondedTimestamp> — persists across loop iterations. */
+const respondedAlerts = new Map<string, number>();
+
+/** Extract the system ID from a [COMBAT WARNING] or [HULL DAMAGE] faction message. */
+function extractAlertSystem(content: string): string | null {
+  // Both alert types end with:  ...| sys_xxxx/poi_yyyy
+  const match = content.match(/\|\s*(sys_[a-z0-9_]+)\//i);
+  return match ? match[1] : null;
+}
+
+/**
+ * Scan recent faction chat for combat alerts from allied bots.
+ * Returns the nearest threatened system if it's within `responseRange` jumps,
+ * or null if there's nothing to respond to.
+ */
+async function checkFactionAlerts(
+  ctx: RoutineContext,
+  responseRange: number,
+): Promise<string | null> {
+  const { bot } = ctx;
+
+  const chatResp = await bot.exec("get_chat_history", { channel: "faction" });
+  if (chatResp.error || !chatResp.result) return null;
+
+  const r = chatResp.result as Record<string, unknown>;
+  const msgs = (
+    Array.isArray(chatResp.result) ? chatResp.result :
+    Array.isArray(r.messages) ? r.messages :
+    Array.isArray(r.history) ? r.history :
+    []
+  ) as Array<Record<string, unknown>>;
+
+  const nowSecs = Date.now() / 1000;
+  const nowMs = Date.now();
+
+  // Walk from newest → oldest (slice().reverse() in case order is oldest-first)
+  for (const msg of [...msgs].reverse()) {
+    const content = (msg.content as string) || (msg.message as string) || (msg.text as string) || "";
+    if (!content.includes("[COMBAT WARNING]") && !content.includes("[HULL DAMAGE]")) continue;
+
+    // Check message age if a timestamp is available
+    const ts = (msg.timestamp as number) || (msg.created_at as number) || 0;
+    if (ts > 0 && nowSecs - ts > ALERT_STALENESS_SECS) continue;
+
+    const alertSystem = extractAlertSystem(content);
+    if (!alertSystem) continue;
+
+    // Already here — no need to divert
+    if (alertSystem === bot.system) continue;
+
+    // Cooldown per system
+    const lastMs = respondedAlerts.get(alertSystem) ?? 0;
+    if (nowMs - lastMs < ALERT_RESPONSE_COOLDOWN_MS) continue;
+
+    // Check proximity via known map routes
+    const route = mapStore.findRoute(bot.system, alertSystem);
+    if (!route || route.length > responseRange) continue;
+
+    return alertSystem;
+  }
+
+  return null;
+}
+
 // ── Hunter routine ───────────────────────────────────────────
 
 export const hunterRoutine: Routine = async function* (ctx: RoutineContext) {
@@ -533,6 +606,28 @@ export const hunterRoutine: Routine = async function* (ctx: RoutineContext) {
         await ensureUndocked(ctx);
       }
       continue;
+    }
+
+    // ── Faction alert check — divert if an ally is nearby and under attack ──
+    yield "faction_alert_check";
+    const alertTarget = await checkFactionAlerts(ctx, settings.responseRange);
+    if (alertTarget) {
+      const sys = mapStore.getSystem(alertTarget);
+      const route = mapStore.findRoute(bot.system, alertTarget);
+      const jumps = route ? route.length : "?";
+      ctx.log("combat", `Faction alert! ${sys?.name || alertTarget} is under attack (${jumps} jump(s)) — diverting to assist`);
+      respondedAlerts.set(alertTarget, Date.now());
+      try {
+        await bot.exec("chat", {
+          channel: "faction",
+          content: `[HUNTER RESPONSE] ${bot.username} en route to ${sys?.name || alertTarget} (${jumps} jump(s)) to assist`,
+        });
+      } catch { /* non-fatal */ }
+      // Override patrol target for this cycle
+      const arrived = await navigateToSystem(ctx, alertTarget, safetyOpts);
+      if (!arrived) {
+        ctx.log("error", `Could not reach ${alertTarget} — resuming normal patrol`);
+      }
     }
 
     // ── Navigate to a huntable (low/unregulated) system ──

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1856,6 +1856,7 @@
         <div class="sidebar-item" onclick="switchSettingsTab('gas_harvester')">GasHarvester</div>
         <div class="sidebar-item" onclick="switchSettingsTab('ice_harvester')">IceHarvester</div>
         <div class="sidebar-item" onclick="switchSettingsTab('salvager')">Salvager</div>
+        <div class="sidebar-item" onclick="switchSettingsTab('hunter')">Hunter</div>
       </div>
       <div class="settings-panel" id="settingsContent">
         <!-- filled by JS -->
@@ -4549,6 +4550,8 @@ function renderSettingsPanel() {
     renderIceHarvesterSettings(panel);
   } else if (activeSettingsTab === 'salvager') {
     renderSalvagerSettings(panel);
+  } else if (activeSettingsTab === 'hunter') {
+    renderHunterSettings(panel);
   }
 }
 
@@ -7357,6 +7360,100 @@ function saveSalvagerSettings() {
   };
   send({ type: 'saveSettings', routine: 'salvager', settings: s });
   settings.salvager = s;
+}
+
+// ── Hunter ──────────────────────────────────────────────────
+function renderHunterSettings(panel) {
+  const h = settings.hunter || {};
+  const currentSystem = h.system || '';
+  const refuelThreshold = h.refuelThreshold ?? 40;
+  const repairThreshold = h.repairThreshold ?? 30;
+  const fleeThreshold = h.fleeThreshold ?? 20;
+  const onlyNPCs = h.onlyNPCs !== false;
+  const responseRange = h.responseRange ?? 3;
+
+  const systemOpts = ['<option value="">(auto — nearest low-sec)</option>'];
+  for (const sys of knownSystems) {
+    const sel = sys.id === currentSystem ? ' selected' : '';
+    const label = sys.name ? `${sys.name} (${sys.id})` : sys.id;
+    systemOpts.push(`<option value="${esc(sys.id)}"${sel}>${esc(label)}</option>`);
+  }
+  if (currentSystem && !knownSystems.find(s => s.id === currentSystem)) {
+    systemOpts.push(`<option value="${esc(currentSystem)}" selected>${esc(currentSystem)}</option>`);
+  }
+
+  panel.innerHTML = `
+    <h3>Hunter Settings</h3>
+    <div class="settings-desc">Pirate hunter bots patrol low-security systems, engage NPC pirates for bounties and loot, and respond to faction combat alerts from allied bots.</div>
+
+    <div class="setting-row">
+      <div>
+        <div class="setting-label">Patrol System</div>
+        <div class="setting-hint">Fixed system to patrol. Leave empty to auto-find the nearest huntable (low/null-sec) system.</div>
+      </div>
+      <select id="set-hunter-system">${systemOpts.join('')}</select>
+    </div>
+
+    <div class="setting-row">
+      <div>
+        <div class="setting-label">Refuel Threshold (%)</div>
+        <div class="setting-hint">Return to station to refuel when fuel drops below this percentage.</div>
+      </div>
+      <input type="number" id="set-hunter-refuelThreshold" min="20" max="80" value="${refuelThreshold}">
+    </div>
+
+    <div class="setting-row">
+      <div>
+        <div class="setting-label">Repair Threshold (%)</div>
+        <div class="setting-hint">Abort patrol and retreat to a high-security system when hull drops below this percentage.</div>
+      </div>
+      <input type="number" id="set-hunter-repairThreshold" min="20" max="80" value="${repairThreshold}">
+    </div>
+
+    <div class="setting-row">
+      <div>
+        <div class="setting-label">Flee Threshold (%)</div>
+        <div class="setting-hint">Emergency flee from an active fight when hull drops below this percentage.</div>
+      </div>
+      <input type="number" id="set-hunter-fleeThreshold" min="5" max="50" value="${fleeThreshold}">
+    </div>
+
+    <div class="setting-row">
+      <div>
+        <div class="setting-label">Attack Mode</div>
+        <div class="setting-hint">Restrict attacks to NPC pirates only, or also engage hostile players.</div>
+      </div>
+      <select id="set-hunter-onlyNPCs">
+        <option value="true"${onlyNPCs ? ' selected' : ''}>NPC Pirates Only (safe)</option>
+        <option value="false"${!onlyNPCs ? ' selected' : ''}>NPCs + Hostile Players</option>
+      </select>
+    </div>
+
+    <div class="setting-row">
+      <div>
+        <div class="setting-label">Faction Alert Response Range (jumps)</div>
+        <div class="setting-hint">Max jumps away to respond when an allied bot broadcasts a [COMBAT WARNING] or [HULL DAMAGE] alert. Set to 0 to disable.</div>
+      </div>
+      <input type="number" id="set-hunter-responseRange" min="0" max="20" value="${responseRange}">
+    </div>
+
+    <div class="settings-save-bar">
+      <button class="primary" onclick="saveHunterSettings()">Save Settings</button>
+    </div>
+  `;
+}
+
+function saveHunterSettings() {
+  const s = {
+    system: document.getElementById('set-hunter-system').value,
+    refuelThreshold: parseInt(document.getElementById('set-hunter-refuelThreshold').value) || 40,
+    repairThreshold: parseInt(document.getElementById('set-hunter-repairThreshold').value) || 30,
+    fleeThreshold: parseInt(document.getElementById('set-hunter-fleeThreshold').value) || 20,
+    onlyNPCs: document.getElementById('set-hunter-onlyNPCs').value === 'true',
+    responseRange: parseInt(document.getElementById('set-hunter-responseRange').value) ?? 3,
+  };
+  send({ type: 'saveSettings', routine: 'hunter', settings: s });
+  settings.hunter = s;
 }
 
 // ── Shipyard ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Faction alert detection**: Hunter reads faction chat each patrol cycle, scanning for `[COMBAT WARNING]` and `[HULL DAMAGE]` messages broadcast by attacked bots. Parses the trailing `| sys_xxxx/poi_yyyy` to extract the threatened system.
- **Proximity check**: Uses `mapStore.findRoute()` to measure jump distance. Only diverts if the alert system is within `responseRange` jumps (default: 3). Skips if the alert is stale (>5 min) or the system is on a 5-minute cooldown.
- **Response**: Logs the diversion, stamps the cooldown, broadcasts `[HUNTER RESPONSE] ... en route to X (N jumps) to assist` to faction chat, then navigates to the alert system and sweeps its POIs for the threat.
- **Hunter settings panel**: New UI panel under Settings → Hunter with controls for patrol system, refuel/repair/flee thresholds, attack mode (NPC-only vs players), and faction alert response range.

## Test plan

- [ ] Start a hunter bot and verify the Settings → Hunter panel appears with correct defaults
- [ ] Save settings and confirm `data/settings.json` has a `hunter` key with the right values
- [ ] Trigger a `[COMBAT WARNING]` in faction chat (manually via the dashboard chat, or by getting another bot attacked) and confirm the hunter logs `Faction alert!` and broadcasts `[HUNTER RESPONSE]`
- [ ] Confirm the hunter does **not** respond if the alert system is farther than `responseRange` jumps
- [ ] Confirm the 5-minute cooldown prevents repeated diversions to the same system
- [ ] Set `responseRange: 0` and confirm no response is triggered