### PR TITLE
Add "remove bot" feature

### DIFF
--- a/src/botmanager.ts
+++ b/src/botmanager.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, appendFileSync, mkdirSync } from "fs";
+import { existsSync, readdirSync, appendFileSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { Bot, type Routine } from "./bot.js";
 import { SessionManager } from "./session.js";
@@ -104,6 +104,8 @@ async function handleAction(action: WebAction): Promise<WebActionResult> {
       return handleStop(action);
     case "add":
       return handleAdd(action);
+    case "remove":
+      return handleRemove(action);
     case "register":
       return handleRegister(action);
     case "chat":
@@ -195,6 +197,28 @@ async function handleAdd(action: WebAction): Promise<WebActionResult> {
   }
   refreshStatusTable();
   return { ok: true, message: `Bot added: ${username}` };
+}
+
+async function handleRemove(action: WebAction): Promise<WebActionResult> {
+  const { username } = action;
+  if (!username) return { ok: false, error: "Username required" };
+
+  const bot = bots.get(username);
+  if (!bot) return { ok: false, error: `Bot not found: ${username}` };
+
+  if (bot.state === "running") bot.stop();
+
+  bots.delete(username);
+  server.clearBotAssignment(username);
+
+  const sessionDir = join(SESSIONS_DIR, username);
+  if (existsSync(sessionDir)) {
+    rmSync(sessionDir, { recursive: true, force: true });
+  }
+
+  server.logSystem(`Bot removed: ${username}`);
+  refreshStatusTable();
+  return { ok: true, message: `Bot removed: ${username}` };
 }
 
 async function handleRegister(action: WebAction): Promise<WebActionResult> {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -2307,7 +2307,8 @@ function renderBots() {
         <select id="routine-${esc(bot.username)}" onclick="event.stopPropagation()">
           ${routines.map(r => `<option value="${esc(r)}"${r === prevRoutine ? ' selected' : ''}>${esc(r)}</option>`).join('')}
         </select>
-        <button class="primary sm" onclick="event.stopPropagation();startBot('${esc(bot.username)}')">Start</button>`;
+        <button class="primary sm" onclick="event.stopPropagation();startBot('${esc(bot.username)}')">Start</button>
+        <button class="danger sm" onclick="event.stopPropagation();removeBot('${esc(bot.username)}')">Remove</button>`;
     } else if (bot.state === 'running') {
       actions = `<button class="danger sm" onclick="event.stopPropagation();stopBot('${esc(bot.username)}')">Stop</button>`;
     }
@@ -2536,7 +2537,8 @@ function renderProfileTopbar() {
       <select id="profile-routine" onchange="renderProfileTopbar()">
         ${routines.map(r => `<option value="${esc(r)}"${r === prevProfileRoutine ? ' selected' : ''}>${esc(r)}</option>`).join('')}
       </select>
-      <button class="primary sm" onclick="startBotFromProfile()">Start</button>`;
+      <button class="primary sm" onclick="startBotFromProfile()">Start</button>
+      <button class="danger sm" onclick="removeBot('${esc(bot.username)}')">Remove</button>`;
   } else if (bot.state === 'running') {
     actions = `<button class="danger sm" onclick="stopBot('${esc(bot.username)}')">Stop</button>`;
   }
@@ -5207,6 +5209,11 @@ function startBot(username) {
 
 function stopBot(username) {
   send({ type: 'stop', bot: username });
+}
+
+function removeBot(username) {
+  if (!confirm(`Remove ${username}? This deletes their session and credentials permanently.`)) return;
+  send({ type: 'remove', username });
 }
 
 function sendChat() {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -8,7 +8,7 @@ import type { ServerWebSocket } from "bun";
 // ── Types ──────────────────────────────────────────────────
 
 export interface WebAction {
-  type: "start" | "stop" | "add" | "register" | "chat" | "saveSettings" | "exec";
+  type: "start" | "stop" | "add" | "register" | "remove" | "chat" | "saveSettings" | "exec";
   bot?: string;
   routine?: string;
   username?: string;


### PR DESCRIPTION
## Summary

- **Remove button** appears next to Start in the bot table and profile topbar — only when the bot is idle or in error state (not while running)
- Clicking Remove shows a `confirm()` dialog before proceeding
- Server-side `handleRemove` stops the bot if running, removes it from the in-memory fleet, clears its `botAssignments` entry in `settings.json`, and deletes `sessions/{username}/` (the credentials file)

## Test plan

- [ ] Add a bot, then remove it while idle — confirm it disappears from the UI and `sessions/` dir is deleted
- [ ] Start a bot, verify Remove button is hidden while running; stop it, then remove
- [ ] Restart the manager and confirm the removed bot does not reappear