### PR TITLE
Fix critical security and reliability issues

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -61,7 +61,11 @@ export class SpaceMoltAPI {
     try {
       await this.ensureSession();
       if (needsV2) await this.ensureV2Session();
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.startsWith("Login failed:")) {
+        return { error: { code: "login_failed", message: msg } };
+      }
       return { error: { code: "connection_failed", message: "Could not connect to server" } };
     }
 
@@ -77,7 +81,11 @@ export class SpaceMoltAPI {
         await this.ensureSession();
         if (needsV2) await this.ensureV2Session();
         resp = await this.doRequest(command, payload);
-      } catch {
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.startsWith("Login failed:")) {
+          return { error: { code: "login_failed", message: msg } };
+        }
         return { error: { code: "connection_failed", message: "Could not reconnect to server" } };
       }
     }
@@ -161,10 +169,11 @@ export class SpaceMoltAPI {
             password: this.credentials.password,
           });
           if (loginResp.error) {
-            logError(`Login failed: ${loginResp.error.message}`);
-          } else {
-            log("system", "Logged in successfully");
+            // Throw so callers get an explicit error rather than continuing with
+            // an unauthenticated session that will fail on every subsequent request.
+            throw new Error(`Login failed: ${loginResp.error.message}`);
           }
+          log("system", "Logged in successfully");
           // Login may return a new session — capture it
           if (loginResp.session) {
             this.session = loginResp.session;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -391,7 +391,11 @@ export class Bot {
     // Only login if we don't already have an active session
     if (!this.api.getSession()) {
       const loggedIn = await this.login();
-      if (!loggedIn) return;
+      if (!loggedIn) {
+        // login() already set _state = "error" and _error; throw so the caller's
+        // .catch() handler fires instead of .then() (which would log "routine finished").
+        throw new Error(this._error || "Login failed");
+      }
     }
 
     this.log("system", `Starting routine: ${routineName}`);
@@ -417,7 +421,9 @@ export class Bot {
       this._error = msg;
       this.log("error", `Routine error: ${msg}`);
       this._state = "error";
-      return;
+      // Re-throw so the caller's .catch() handler fires, ensuring the bot
+      // assignment is cleared and "crashed" is logged rather than "finished".
+      throw err;
     }
 
     this._state = "idle";

--- a/src/botmanager.ts
+++ b/src/botmanager.ts
@@ -154,8 +154,9 @@ async function handleStart(action: WebAction): Promise<WebActionResult> {
   bot.start(routineKey, routine.fn, startOpts).then(() => {
     server.logSystem(`Bot ${bot.username} routine finished.`);
     server.clearBotAssignment(botName);
-  }).catch((err) => {
-    server.logSystem(`Bot ${bot.username} crashed: ${err}`);
+  }).catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    server.logSystem(`Bot ${bot.username} stopped with error: ${msg}`);
     server.clearBotAssignment(botName);
   });
 
@@ -256,8 +257,7 @@ async function handleRegister(action: WebAction): Promise<WebActionResult> {
     return { ok: false, error: "No password returned" };
   }
 
-  server.logSystem(`Registration successful! PASSWORD: ${password}`);
-  server.logSystem("SAVE THIS PASSWORD! It cannot be recovered.");
+  server.logSystem(`Registration successful for ${username} — password returned to dashboard only.`);
 
   const session = new SessionManager(username, BASE_DIR);
   session.saveCredentials({ username, password, empire: selectedEmpire, playerId });

--- a/src/catalogstore.ts
+++ b/src/catalogstore.ts
@@ -53,6 +53,7 @@ class CatalogStore {
   private data: CatalogData;
   private dirty = false;
   private saveTimer: ReturnType<typeof setTimeout> | null = null;
+  private _fetchPromise: Promise<void> | null = null;
 
   constructor() {
     this.data = this.load();
@@ -115,6 +116,17 @@ class CatalogStore {
 
   /** Paginate all 4 catalog types and store results. */
   async fetchAll(api: SpaceMoltAPI): Promise<void> {
+    // If a fetch is already in progress, wait for it rather than running a
+    // concurrent fetch that would partially overwrite results.
+    if (this._fetchPromise) return this._fetchPromise;
+
+    this._fetchPromise = this._doFetchAll(api).finally(() => {
+      this._fetchPromise = null;
+    });
+    return this._fetchPromise;
+  }
+
+  private async _doFetchAll(api: SpaceMoltAPI): Promise<void> {
     const types = ["items", "ships", "skills", "recipes"] as const;
     const results: Record<string, Record<string, unknown>> = {
       items: {},

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -3160,6 +3160,7 @@ let autoRouteInProgress = false;
 
 function mcAutoRoute() {
   if (!profileBot) return;
+  const routeBot = profileBot; // capture now — bot switches must not redirect jumps
   const target = val('mc-jump-sys');
   if (!target) return;
   if (autoRouteInProgress) {
@@ -3174,7 +3175,7 @@ function mcAutoRoute() {
   const ts = new Date().toLocaleTimeString('en-US', { hour12: false });
   logResponse(`<span class="resp-cmd">${ts} > find_route to ${esc(target)}</span>`);
 
-  sendExec(profileBot, 'find_route', { target_system: target }, async (result) => {
+  sendExec(routeBot, 'find_route', { target_system: target }, async (result) => {
     if (!result.ok || !result.data) {
       logResponse(`<span class="resp-err">Route failed: ${esc(result.error || 'no route data')}</span>`);
       autoRouteInProgress = false;
@@ -3193,7 +3194,7 @@ function mcAutoRoute() {
 
     // Route is an array of system IDs — first entry is current system, skip it
     const allHops = route.map(h => typeof h === 'string' ? h : (h.system_id || h.id || h));
-    const bot = getProfileBot();
+    const bot = bots.find(b => b.username === routeBot);
     const currentSys = bot ? (bot.system || '') : '';
     const hops = allHops[0] === currentSys ? allHops.slice(1) : allHops;
     logResponse(`<span class="resp-ok">Route: ${allHops.map(h => esc(resolveLocation(String(h)) || String(h))).join(' → ')} (${hops.length} jump${hops.length !== 1 ? 's' : ''})</span>`);
@@ -3207,7 +3208,7 @@ function mcAutoRoute() {
       logResponse(`<span class="resp-cmd">${hopTs} > jump ${esc(hop)} (${i + 1}/${hops.length})</span>`);
 
       const jumpOk = await new Promise(resolve => {
-        sendExec(profileBot, 'jump', { target_system: hop }, (jr) => {
+        sendExec(routeBot, 'jump', { target_system: hop }, (jr) => {
           if (jr.ok) {
             logResponse(`<span class="resp-ok">Arrived in ${esc(hop)}</span>`);
             resolve(true);
@@ -3232,8 +3233,8 @@ function mcAutoRoute() {
 
     // Refresh system data for new location
     setTimeout(() => {
-      if (profileBot) {
-        fetchSystemData(profileBot);
+      fetchSystemData(routeBot);
+      if (profileBot === routeBot) {
         renderProfileSidebar();
         renderManualControls();
       }


### PR DESCRIPTION
## Summary

- **Security**: Registration no longer writes the generated password to the system log (`data/logs/system.log`). The password is only returned in the API response to the dashboard.
- **Reliability**: `ensureSession()` now throws on login failure instead of silently continuing with an unauthenticated session. Callers receive a `login_failed` error code rather than a confusing `not_authenticated` on the next request.
- **Reliability**: `catalogStore.fetchAll()` is now guarded with an in-flight promise — concurrent callers (e.g. multiple bots logging in at startup) share one fetch instead of running parallel requests that partially overwrite each other.
- **Reliability**: `Bot.start()` now throws when login fails, so the caller's `.catch()` handler fires (instead of `.then()`), giving the correct "stopped with error" log message.
- **Reliability**: Routine errors are re-thrown from `Bot.start()` so `.catch()` always fires on crash, ensuring `clearBotAssignment()` is reliably called and the bot assignment is cleared from `settings.json`.

## Test plan

- [ ] Register a new bot and confirm the password does not appear in `data/logs/system.log`
- [ ] Add a bot with incorrect credentials and confirm the error is logged as "stopped with error" (not "routine finished")
- [ ] Start two bots simultaneously from a cold start and confirm catalog is fetched once, not twice
- [ ] Start a bot whose routine throws immediately and confirm the assignment is cleared so it does not auto-resume on restart