### PR TITLE
Fallback to all recipes when skill-grind finds nothing in configured set

### DIFF
--- a/src/routines/crafter.ts
+++ b/src/routines/crafter.ts
@@ -575,7 +575,11 @@ export const crafterRoutine: Routine = async function* (ctx: RoutineContext) {
       if (!skillCheck.ok) {
         // Skill too low — grind XP on simpler recipes instead of pulling materials
         const allowedIds = new Set(settings.craftLimits.map(cl => cl.recipeId));
-        const xpCrafted = await grindCraftingXP(ctx, recipes, recipeIndex, allowedIds);
+        let xpCrafted = await grindCraftingXP(ctx, recipes, recipeIndex, allowedIds);
+        if (xpCrafted.length === 0) {
+          // Fallback: search all recipes for anything we have ingredients for right now
+          xpCrafted = await grindCraftingXP(ctx, recipes, recipeIndex);
+        }
         if (xpCrafted.length > 0) {
           skillSummary.push(`${recipe.name} (${skillCheck.reason}, ground ${xpCrafted.join(", ")} for XP)`);
         } else {
@@ -671,7 +675,11 @@ export const crafterRoutine: Routine = async function* (ctx: RoutineContext) {
       // ── Skill too low: try grinding XP on configured recipes only ──
       if (hitSkillBlock && bot.state === "running") {
         const allowedIds = new Set(settings.craftLimits.map(cl => cl.recipeId));
-        const xpCrafted = await grindCraftingXP(ctx, recipes, recipeIndex, allowedIds);
+        let xpCrafted = await grindCraftingXP(ctx, recipes, recipeIndex, allowedIds);
+        if (xpCrafted.length === 0) {
+          // Fallback: search all recipes for anything we have ingredients for right now
+          xpCrafted = await grindCraftingXP(ctx, recipes, recipeIndex);
+        }
         if (xpCrafted.length > 0) {
           skillSummary.push(`${recipe.name} (skill too low, ground ${xpCrafted.join(", ")} for XP)`);
         } else {


### PR DESCRIPTION
## Summary
- When crafting is blocked by a skill requirement, the routine tries to grind XP on simpler configured recipes
- If no configured recipes (or their prerequisites) can be crafted either, it now falls back to scanning the full recipe catalog for anything the bot already has ingredients for and meets the skill requirement for
- Fixes the case where all configured recipes need skills the bot doesn't have yet and the bot is left idle

## Test plan
- [ ] Bot with skill-blocked recipes and no matching configured XP recipes should now craft available catalog recipes for XP instead of doing nothing